### PR TITLE
Prolific Id fix + deleting "next trial" page

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,9 +57,9 @@
   var instr_imglist = [];
   for (var ii = 0; ii < 2; ii++) {
     instr_imglist.push(instr_src + 'Inst' + (ii + 1).toString() + '.png');
-    console.log("test"+ii);
+    /*console.log("test"+ii);*/
   }
-  console.log(instr_imglist);
+  /*console.log(instr_imglist);*/
   
   var practice_id_entry = {
     type: "survey-html-form",
@@ -72,7 +72,7 @@
     // show_page_number: false,
     data: {
       exp_stage: "practice_id_entry",
-      sbj_id: sbj_id,
+      /*sbj_id: sbj_id,*/
     }
   };
 

--- a/index.html
+++ b/index.html
@@ -60,6 +60,21 @@
     console.log("test"+ii);
   }
   console.log(instr_imglist);
+  
+  var practice_id_entry = {
+    type: "survey-html-form",
+    preamble: "<div><p>Enter your Prolific ID:</p> </div >",
+    html: '<p><input id="id_box" name="proli_id" type="text" /></p>',
+    autofocus: "id_box",
+    // allow_keys: true,
+    // show_clickable_nav: true,
+    // allow_backward: false,
+    // show_page_number: false,
+    data: {
+      exp_stage: "practice_id_entry",
+      sbj_id: sbj_id,
+    }
+  };
 
   function generate_instruction_page(imglist) {
     var instructions_page = {
@@ -126,6 +141,8 @@
     fullscreen_mode: true
   });
 
+  jspsych_session.push(practice_id_entry);
+    
   jspsych_session.push(generate_instruction_page(instr_imglist));
 
   jspsych_session.push({

--- a/lib/bubble-view_main.js
+++ b/lib/bubble-view_main.js
@@ -99,7 +99,7 @@ function generate_practice_block(
   var num_trial = prac_seq.length;
 
   for (var ii = 0; ii < num_trial; ii++) {
-    var start_trial = {
+    /*var start_trial = {
       type: "instructions",
       pages: [
         "<p class = block-text>" +
@@ -118,7 +118,7 @@ function generate_practice_block(
         sbj_id: sbj_id,
       },
     };
-    block_sequence.push(start_trial);
+    block_sequence.push(start_trial);*/
 
     var bubble_phase = {
       type: "bubble-view",

--- a/lib/bubble-view_main.js
+++ b/lib/bubble-view_main.js
@@ -98,22 +98,6 @@ function generate_practice_block(
   var block_sequence = [];
   var num_trial = prac_seq.length;
 
-  var practice_id_entry = {
-    type: "survey-html-form",
-    preamble: "<div><p>Enter your Prolific ID:</p> </div >",
-    html: '<p><input id="id_box" name="proli_id" type="text" /></p>',
-    autofocus: "id_box",
-    // allow_keys: true,
-    // show_clickable_nav: true,
-    // allow_backward: false,
-    // show_page_number: false,
-    data: {
-      exp_stage: "practice_id_entry",
-      sbj_id: sbj_id,
-    },
-  };
-  block_sequence.push(practice_id_entry);
-
   for (var ii = 0; ii < num_trial; ii++) {
     var start_trial = {
       type: "instructions",


### PR DESCRIPTION
1. I moved the part responsible for creating the Prolific ID request from bubble-view_main.js to the html file. This way you can push the request anywhere in the flow of the experiment (right now there's a "jspsych_session.push(practice_id_entry);" right after entering full screen, but you can move that anywhere).
2. I deleted the start_trial variable from bubble-view_main.js. It appeared before every trial because it was inside a for loop. If you want a screen showing up just once, saying that "beware, practice trials are about to start", you can just make such a page in the html file where you push all the parts of the experiment.